### PR TITLE
Add noopener to a.rel property

### DIFF
--- a/src/Banner.js
+++ b/src/Banner.js
@@ -218,7 +218,7 @@ export default function Banner() {
                 <div className="banner-right-item">
                   <a
                     href="https://github.com/jaredreich/calcutext"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     target="_blank"
                   >
                     <img src={iconGitHub(COLOR_GRAY)} alt="GitHub" />


### PR DESCRIPTION
Build failed on netlify with the following error:
```
Failed to compile.
./src/Banner.js
  Line 222:21:  Using target="_blank" without rel="noopener noreferrer" is a security risk: see https://mathiasbynens.github.io/rel-noopener  react/jsx-no-target-blank
​
────────────────────────────────────────────────────────────────
  "build.command" failed                                        
────────────────────────────────────────────────────────────────
```

This PR fixes that.